### PR TITLE
fix: rtp on death on custom worlds

### DIFF
--- a/src/main/java/me/SuperRonanCraft/BetterRTP/references/rtpinfo/worlds/WorldCustom.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/references/rtpinfo/worlds/WorldCustom.java
@@ -45,6 +45,12 @@ public class WorldCustom implements RTPWorld, RTPWorld_Defaulted {
                         BetterRTP.debug("- UseWorldBorder: " + this.useWorldborder);
                     }
                 }
+                if (test.get("RTPOnDeath") != null) {
+                    if (test.get("RTPOnDeath").getClass() == Boolean.class) {
+                        RTPOnDeath = Boolean.parseBoolean(test.get("RTPOnDeath").toString());
+                        BetterRTP.debug("- RTPOnDeath: " + this.RTPOnDeath);
+                    }
+                }
                 if (test.get("CenterX") != null) {
                     if (test.get("CenterX").getClass() == Integer.class) {
                         centerX = Integer.parseInt((test.get("CenterX")).toString());
@@ -203,7 +209,8 @@ public class WorldCustom implements RTPWorld, RTPWorld_Defaulted {
         return cooldown;
     }
 
-    @Override public boolean getRTPOnDeath() {
+    @Override
+    public boolean getRTPOnDeath() {
         return RTPOnDeath;
     }
 
@@ -268,7 +275,8 @@ public class WorldCustom implements RTPWorld, RTPWorld_Defaulted {
         this.cooldown = value;
     }
 
-    @Override public void setRTPOnDeath(boolean bool) {
-        RTPOnDeath = bool;
+    @Override
+    public void setRTPOnDeath(boolean value) {
+        this.RTPOnDeath = value;
     }
 }

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/references/rtpinfo/worlds/WorldDefault.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/references/rtpinfo/worlds/WorldDefault.java
@@ -76,6 +76,7 @@ public class WorldDefault implements RTPWorld {
         if (BetterRTP.getInstance().getSettings().isDebug()) {
             Logger log = BetterRTP.getInstance().getLogger();
             log.info("- UseWorldBorder: " + this.useWorldborder);
+            log.info("- RTPOnDeath: " + this.RTPOnDeath);
             log.info("- CenterX: " + this.centerX);
             log.info("- CenterZ: " + this.centerZ);
             log.info("- MaxRadius: " + this.maxRad);
@@ -151,7 +152,8 @@ public class WorldDefault implements RTPWorld {
         return BetterRTP.getInstance().getCooldowns().getDefaultCooldownTime();
     }
 
-    @Override public boolean getRTPOnDeath() {
+    @Override
+    public boolean getRTPOnDeath() {
         return RTPOnDeath;
     }
 }


### PR DESCRIPTION
This PR fixes RTP on death config on custom worlds and adds it to debug print.
Before those changes, only default value for RTPOnDeath was used, the one in custom world was not used at all.

I'm attaching log and config as examples.

[config.txt](https://github.com/user-attachments/files/19896564/config.txt)
[log.txt](https://github.com/user-attachments/files/19896565/log.txt)
