### PR TITLE
Add verified Folia 26.1.2 compatibility

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,21 +1,44 @@
-name: Maven Tests
+name: Build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
+    name: Build BetterRTP and Addons
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v1
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: 17
+          distribution: temurin
+          java-version: '21'
+          cache: maven
 
-      - name: Configure Maven settings
-        run: cp settings.xml $HOME/.m2/settings.xml
+      - name: Build and install BetterRTP
+        run: mvn -B -DskipTests install
 
-      - name: Build and test with Maven
-        run: mvn test
+      - name: Build BetterRTPAddons
+        run: mvn -B -DskipTests package
+        working-directory: BetterRTPAddons
+
+      - name: Upload BetterRTP artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: BetterRTP
+          path: target/BetterRTP-*.jar
+          if-no-files-found: error
+
+      - name: Upload BetterRTPAddons artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: BetterRTPAddons
+          path: BetterRTPAddons/target/BetterRTPAddons-*.jar
+          if-no-files-found: error

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -15,11 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
           cache: maven
 
       - name: Build and install BetterRTP

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -25,6 +25,117 @@ jobs:
       - name: Build and install BetterRTP
         run: mvn -B -DskipTests install
 
+      - name: Smoke test on Folia 26.1.2 build 8
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          server_dir="$RUNNER_TEMP/folia-smoke"
+          mkdir -p "$server_dir/plugins" "$server_dir/cache"
+
+          curl --fail --location --retry 5 --retry-all-errors \
+            --output "$server_dir/folia.jar" \
+            "https://fill-data.papermc.io/v1/objects/607afd1c3320008e1ffd2eaee6780ace4419d5f8c527b75e79f259be79ebf57b/folia-26.1.2-8.jar"
+          echo "607afd1c3320008e1ffd2eaee6780ace4419d5f8c527b75e79f259be79ebf57b  $server_dir/folia.jar" | sha256sum --check
+
+          curl --fail --location --retry 5 --retry-all-errors \
+            --output "$server_dir/cache/mojang_26.1.2.jar" \
+            "https://piston-data.mojang.com/v1/objects/97ccd4c0ed3f81bbb7bfacddd1090b0c56f9bc51/server.jar"
+          echo "cd47e7c38328f64768fd17af8fcd8b22496b40b63d4ffee81e71ae059fedcb42  $server_dir/cache/mojang_26.1.2.jar" | sha256sum --check
+
+          cp target/BetterRTP-*.jar "$server_dir/plugins/BetterRTP.jar"
+          printf 'eula=true\n' > "$server_dir/eula.txt"
+          printf '%s\n' \
+            'allow-nether=false' \
+            'enable-query=false' \
+            'enable-rcon=false' \
+            'enable-status=false' \
+            'generate-structures=false' \
+            'level-name=world' \
+            'online-mode=false' \
+            'server-ip=127.0.0.1' \
+            'server-port=25585' \
+            'simulation-distance=2' \
+            'spawn-protection=0' \
+            'view-distance=2' > "$server_dir/server.properties"
+
+          SERVER_DIR="$server_dir" python3 - <<'PY'
+          import os
+          import subprocess
+          import sys
+          import threading
+
+          server_dir = os.environ["SERVER_DIR"]
+          process = subprocess.Popen(
+              ["java", "-Xms1G", "-Xmx1G", "-jar", "folia.jar", "--nogui"],
+              cwd=server_dir,
+              stdin=subprocess.PIPE,
+              stdout=subprocess.PIPE,
+              stderr=subprocess.STDOUT,
+              text=True,
+              bufsize=1,
+          )
+
+          output = []
+          commands_sent = False
+          timed_out = False
+
+          def stop_server():
+              if process.poll() is None:
+                  process.stdin.write("stop\n")
+                  process.stdin.flush()
+
+          def run_checks():
+              if process.poll() is None:
+                  process.stdin.write("version\nplugins\nbrtp version\nbrtp info\n")
+                  process.stdin.flush()
+                  threading.Timer(5, stop_server).start()
+
+          def abort_server():
+              global timed_out
+              timed_out = True
+              if process.poll() is None:
+                  process.kill()
+
+          timeout = threading.Timer(180, abort_server)
+          timeout.start()
+
+          for line in process.stdout:
+              print(line, end="")
+              output.append(line)
+              if not commands_sent and "Done (" in line:
+                  commands_sent = True
+                  # Folia 26.1.2 logs Done just before its console command source
+                  # has a world. Give that source one global tick to settle.
+                  threading.Timer(2, run_checks).start()
+
+          return_code = process.wait()
+          timeout.cancel()
+          log = "".join(output)
+
+          required = (
+              "Loading Folia 26.1.2-8-",
+              "Enabling BetterRTP v",
+              "[BetterRTP] Version #",
+              "----- BetterRTP | Info -----",
+          )
+          missing = [entry for entry in required if entry not in log]
+          forbidden = (
+              "Could not load 'plugins/BetterRTP.jar'",
+              "Error occurred while enabling BetterRTP",
+              "Thread ownership",
+          )
+          found = [entry for entry in forbidden if entry in log]
+
+          if timed_out or return_code != 0 or missing or found:
+              print(
+                  f"Smoke test failed: timed_out={timed_out}, return_code={return_code}, "
+                  f"missing={missing}, forbidden={found}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          PY
+
       - name: Build BetterRTPAddons
         run: mvn -B -DskipTests package
         working-directory: BetterRTPAddons

--- a/BetterRTPAddons/README.md
+++ b/BetterRTPAddons/README.md
@@ -14,6 +14,8 @@ BetterRTPAddons uses and is compiled with the following libraries:
 
 - [Folia API](https://github.com/PaperMC/Folia) (provided) - Modern Folia server API target for scheduler and teleport compatibility.
 
+Builds targeting Folia 26.1.2+ require Java 25 or newer.
+
 ## Where's the Wiki?  
 The wiki is available [here](../../../wiki)!
     

--- a/BetterRTPAddons/README.md
+++ b/BetterRTPAddons/README.md
@@ -12,7 +12,7 @@ feel free to fork one of the language files and help translate!
 ## Libraries
 BetterRTPAddons uses and is compiled with the following libraries:
 
-- [PaperLib](https://github.com/PaperMC/PaperLib) (included) - Library for interfacing with PaperMC specific APIs, used for async chunk loading.
+- [Folia API](https://github.com/PaperMC/Folia) (provided) - Modern Folia server API target for scheduler and teleport compatibility.
 
 ## Where's the Wiki?  
 The wiki is available [here](../../../wiki)!

--- a/BetterRTPAddons/pom.xml
+++ b/BetterRTPAddons/pom.xml
@@ -10,10 +10,29 @@
     <version>1.8.10</version>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!-- Local Server Building -->
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <configuration>
+                            <outputDirectory>../../../Java/plugins</outputDirectory>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <resources>
             <resource>
@@ -24,44 +43,21 @@
         <finalName>${project.artifactId}-${project.version}</finalName>
         <plugins>
             <plugin>
-                <!-- Shade PaperLib into project -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.1</version>
-                <configuration>
-                    <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
-                    <relocations>
-                        <relocation>
-                            <pattern>io.papermc.lib</pattern>
-                            <shadedPattern>me.SuperRonanCraft.BetterRTPAddons.paperlib</shadedPattern>
-                        </relocation>
-                    </relocations>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <!-- Local Server Building -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
-                <configuration>
-                    <outputDirectory>../../../Java/plugins</outputDirectory>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.14.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>21</source>
+                    <target>21</target>
+                    <release>21</release>
+                    <proc>full</proc>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.38</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
         </plugins>
@@ -75,61 +71,52 @@
         <!-- PaperMC Repo -->
         <repository>
             <id>papermc</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
         <!-- ProtocolLib Repo -->
         <repository>
             <id>dmulloy2-repo</id>
             <url>https://repo.dmulloy2.net/nexus/repository/public/</url>
         </repository>
+        <repository>
+            <id>minecodes-repository-releases</id>
+            <name>mineCodes Organization Repository</name>
+            <url>https://repository.minecodes.pl/releases</url>
+        </repository>
     </repositories>
     <dependencies>
-        <!--Spigot API-->
+        <!-- Folia API -->
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <groupId>dev.folia</groupId>
+            <artifactId>folia-api</artifactId>
+            <version>26.1.2.build.8-stable</version>
             <scope>provided</scope>
-        </dependency>
-        <!-- Spigot Stuff -->
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <!-- Paper Library for Async Chunk/Teleport -->
-        <dependency>
-            <groupId>io.papermc</groupId>
-            <artifactId>paperlib</artifactId>
-            <version>1.0.5</version>
-            <scope>compile</scope>
         </dependency>
         <!-- BetterRTP -->
         <dependency>
             <groupId>me.SuperRonanCraft</groupId>
             <artifactId>BetterRTP</artifactId>
-            <version>LATEST</version>
+            <version>3.6.13</version>
             <scope>provided</scope>
         </dependency>
         <!-- ProtocolLib -->
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.5.0</version>
+            <version>5.3.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.38</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>19.0.0</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/BetterRTPAddons/pom.xml
+++ b/BetterRTPAddons/pom.xml
@@ -10,7 +10,7 @@
     <version>1.8.10</version>
 
     <properties>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -47,9 +47,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
-                    <release>21</release>
+                    <source>25</source>
+                    <target>25</target>
+                    <release>25</release>
                     <proc>full</proc>
                     <annotationProcessorPaths>
                         <path>

--- a/BetterRTPAddons/src/main/java/me/SuperRonanCraft/BetterRTPAddons/addons/flashback/FlashbackPlayer.java
+++ b/BetterRTPAddons/src/main/java/me/SuperRonanCraft/BetterRTPAddons/addons/flashback/FlashbackPlayer.java
@@ -1,11 +1,8 @@
 package me.SuperRonanCraft.BetterRTPAddons.addons.flashback;
 
-import io.papermc.lib.PaperLib;
-import me.SuperRonanCraft.BetterRTPAddons.Main;
-import org.bukkit.Bukkit;
+import me.SuperRonanCraft.BetterRTP.versions.AsyncHandler;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitTask;
 
 import java.util.*;
 
@@ -13,7 +10,7 @@ public class FlashbackPlayer {
     Player p;
     Location oldLoc;
     AddonFlashback plugin;
-    List<BukkitTask> tasks = new ArrayList<>();
+    List<Object> tasks = new ArrayList<>();
 
     public FlashbackPlayer(AddonFlashback plugin, Player p, Location oldLoc, Long seconds, HashMap<Long, String> warnings) {
         this.plugin = plugin;
@@ -21,7 +18,7 @@ public class FlashbackPlayer {
         this.oldLoc = oldLoc;
         if (warnings != null)
             createTimers(seconds, orderMap(warnings));
-        tasks.add(Bukkit.getScheduler().runTaskLater(Main.getInstance(), runFlashback(seconds), 20L * seconds));
+        tasks.add(AsyncHandler.syncAtEntityLaterTask(p, runFlashback(seconds), 20L * seconds));
     }
 
     void createTimers(Long seconds, TreeMap<Long, String> warnings) {
@@ -29,7 +26,7 @@ public class FlashbackPlayer {
             String str = entry.getValue();
             long time = seconds - entry.getKey();
             if (time >= 0)
-                tasks.add(Bukkit.getScheduler().runTaskLater(Main.getInstance(), runWarning(str), 20L * time));
+                tasks.add(AsyncHandler.syncAtEntityLaterTask(p, runWarning(str), 20L * time));
         }
     }
 
@@ -42,8 +39,10 @@ public class FlashbackPlayer {
             p.sendMessage("A Database error has occurred!");
         return () -> {
             plugin.msgs.getWarning(p);
-            PaperLib.teleportAsync(p, oldLoc);
-            completed();
+            AsyncHandler.teleportAsync(p, oldLoc).thenAccept(success -> {
+                if (success)
+                    AsyncHandler.syncAtEntity(p, this::completed);
+            });
         };
     }
 
@@ -52,8 +51,8 @@ public class FlashbackPlayer {
     }
 
     public void cancel() {
-        for (BukkitTask task : tasks)
-            task.cancel();
+        for (Object task : tasks)
+            AsyncHandler.cancelTask(task);
     }
 
     private void completed() {

--- a/BetterRTPAddons/src/main/java/me/SuperRonanCraft/BetterRTPAddons/addons/parties/PartyData.java
+++ b/BetterRTPAddons/src/main/java/me/SuperRonanCraft/BetterRTPAddons/addons/parties/PartyData.java
@@ -1,16 +1,12 @@
 package me.SuperRonanCraft.BetterRTPAddons.addons.parties;
 
-import io.papermc.lib.PaperLib;
 import lombok.Getter;
 import me.SuperRonanCraft.BetterRTP.BetterRTP;
 import me.SuperRonanCraft.BetterRTP.references.PermissionNode;
-import me.SuperRonanCraft.BetterRTP.references.Permissions;
 import me.SuperRonanCraft.BetterRTP.references.customEvents.RTP_TeleportPostEvent;
-import me.SuperRonanCraft.BetterRTP.references.rtpinfo.CooldownData;
+import me.SuperRonanCraft.BetterRTP.versions.AsyncHandler;
 import org.bukkit.Location;
-import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.event.player.PlayerTeleportEvent;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -87,20 +83,26 @@ public class PartyData {
             if (!p.equals(getLeader())) {
                 Location loc = e.getLocation();
                 //Async tp players
-                PaperLib.teleportAsync(p, loc, PlayerTeleportEvent.TeleportCause.PLUGIN).thenRun(() -> {
-                        /*BetterRTP.getInstance().getText().getSuccessBypass(p,
-                                String.valueOf(loc.getBlockX()),
-                                String.valueOf(loc.getBlockY()),
-                                String.valueOf(loc.getBlockZ()),
-                                loc.getWorld().getName(),
-                                1);*/
-                        BetterRTP.getInstance().getRTP().getTeleport().afterTeleport(p, loc, e.getWorldPlayer(), 0, e.getOldLocation(), e.getType());
+                AsyncHandler.syncAtEntity(p, () -> {
+                    AsyncHandler.teleportAsync(p, loc).thenAccept(success -> {
+                        if (success) {
+                            AsyncHandler.syncAtEntity(p, () -> {
+                                /*BetterRTP.getInstance().getText().getSuccessBypass(p,
+                                        String.valueOf(loc.getBlockX()),
+                                        String.valueOf(loc.getBlockY()),
+                                        String.valueOf(loc.getBlockZ()),
+                                        loc.getWorld().getName(),
+                                        1);*/
+                                BetterRTP.getInstance().getRTP().getTeleport().afterTeleport(p, loc, e.getWorldPlayer(), 0, e.getOldLocation(), e.getType());
+                            });
+                        }
+                    });
+                    //Set cooldowns
+                    if (!PermissionNode.BYPASS_COOLDOWN.check(p)) {
+                        BetterRTP.getInstance().getCooldowns().add(p, loc.getWorld());
+                        //BetterRTP.getInstance().getPlayerDataManager().getData(p).getCooldowns().put(loc.getWorld(), new CooldownData(p.getUniqueId(), System.currentTimeMillis(), loc.getWorld()));
+                    }
                 });
-                //Set cooldowns
-                if (!PermissionNode.BYPASS_COOLDOWN.check(p)) {
-                    BetterRTP.getInstance().getCooldowns().add(p, loc.getWorld());
-                    //BetterRTP.getInstance().getPlayerDataManager().getData(p).getCooldowns().put(loc.getWorld(), new CooldownData(p.getUniqueId(), System.currentTimeMillis(), loc.getWorld()));
-                }
             }
         });
     }

--- a/BetterRTPAddons/src/main/java/me/SuperRonanCraft/BetterRTPAddons/addons/portals/region/PortalsCache.java
+++ b/BetterRTPAddons/src/main/java/me/SuperRonanCraft/BetterRTPAddons/addons/portals/region/PortalsCache.java
@@ -6,7 +6,7 @@ import com.comphenix.protocol.ProtocolManager;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.wrappers.BlockPosition;
 import com.comphenix.protocol.wrappers.WrappedBlockData;
-import me.SuperRonanCraft.BetterRTPAddons.Main;
+import me.SuperRonanCraft.BetterRTP.versions.AsyncHandler;
 import me.SuperRonanCraft.BetterRTPAddons.addons.portals.AddonPortals;
 import me.SuperRonanCraft.BetterRTPAddons.packets.BlockChangeArray;
 import me.SuperRonanCraft.BetterRTPAddons.packets.WrapperPlayServerBlockChange;
@@ -17,7 +17,6 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
 
@@ -123,7 +122,7 @@ public class PortalsCache {
 
     private void preview(Location loc1, Location loc2) {
         ProtocolManager pm = ProtocolLibrary.getProtocolManager();
-        Bukkit.getScheduler().runTask(Main.getInstance(), () -> {
+        AsyncHandler.syncAtLocation(loc1, () -> {
             PacketContainer packet = pm
                     .createPacket(PacketType.Play.Server.MULTI_BLOCK_CHANGE);
             Chunk chunk = loc1.getChunk();
@@ -147,12 +146,13 @@ public class PortalsCache {
 
             wrapper.setRecordData(change);
             for (Player player : Bukkit.getOnlinePlayers()) {
-                try {
-                    pm.sendServerPacket(player, packet);
-                } catch (InvocationTargetException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
-                }
+                AsyncHandler.syncAtEntity(player, () -> {
+                    try {
+                        pm.sendServerPacket(player, packet);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                });
             }
 
         });

--- a/BetterRTPAddons/src/main/java/me/SuperRonanCraft/BetterRTPAddons/addons/portals/region/PortalsRegionInfo.java
+++ b/BetterRTPAddons/src/main/java/me/SuperRonanCraft/BetterRTPAddons/addons/portals/region/PortalsRegionInfo.java
@@ -1,9 +1,8 @@
 package me.SuperRonanCraft.BetterRTPAddons.addons.portals.region;
 
 import org.bukkit.Location;
-import org.bukkit.entity.Player;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class PortalsRegionInfo {
 

--- a/BetterRTPAddons/src/main/java/me/SuperRonanCraft/BetterRTPAddons/addons/rtpmenu/RTPMenu_Refresh.java
+++ b/BetterRTPAddons/src/main/java/me/SuperRonanCraft/BetterRTPAddons/addons/rtpmenu/RTPMenu_Refresh.java
@@ -1,5 +1,6 @@
 package me.SuperRonanCraft.BetterRTPAddons.addons.rtpmenu;
 
+import me.SuperRonanCraft.BetterRTP.versions.AsyncHandler;
 import me.SuperRonanCraft.BetterRTPAddons.Main;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -8,15 +9,13 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.scheduler.BukkitTask;
 
 public class RTPMenu_Refresh implements Listener {
 
     private final AddonRTPMenu addon;
     private final Player player;
     private final int time;
-    private BukkitTask task;
+    private Object task;
     private boolean opening = true;
 
     RTPMenu_Refresh(AddonRTPMenu addon, Player player, int time) {
@@ -38,11 +37,7 @@ public class RTPMenu_Refresh implements Listener {
             return;
         }
         opening = false;
-        this.task = new BukkitRunnable() {
-            @Override public void run() {
-                start();
-            }
-        }.runTaskLater(Main.getInstance(), time);
+        this.task = AsyncHandler.syncAtEntityLaterTask(player, this::start, time);
     }
 
     @EventHandler
@@ -61,7 +56,7 @@ public class RTPMenu_Refresh implements Listener {
 
     void cancel() {
         if (task != null)
-            task.cancel();
+            AsyncHandler.cancelTask(task);
         HandlerList.unregisterAll(this);
     }
 

--- a/BetterRTPAddons/src/main/java/me/SuperRonanCraft/BetterRTPAddons/packets/AbstractPacket.java
+++ b/BetterRTPAddons/src/main/java/me/SuperRonanCraft/BetterRTPAddons/packets/AbstractPacket.java
@@ -1,7 +1,5 @@
 package me.SuperRonanCraft.BetterRTPAddons.packets;
 
-import java.lang.reflect.InvocationTargetException;
-
 import org.bukkit.entity.Player;
 
 import com.comphenix.protocol.PacketType;
@@ -49,7 +47,7 @@ public abstract class AbstractPacket {
         try {
             ProtocolLibrary.getProtocolManager().sendServerPacket(receiver,
                     getHandle());
-        } catch (InvocationTargetException e) {
+        } catch (Exception e) {
             throw new RuntimeException("Cannot send packet.", e);
         }
     }
@@ -72,7 +70,7 @@ public abstract class AbstractPacket {
     @Deprecated
     public void recievePacket(Player sender) {
         try {
-            ProtocolLibrary.getProtocolManager().recieveClientPacket(sender,
+            ProtocolLibrary.getProtocolManager().receiveClientPacket(sender,
                     getHandle());
         } catch (Exception e) {
             throw new RuntimeException("Cannot recieve packet.", e);
@@ -87,7 +85,7 @@ public abstract class AbstractPacket {
      */
     public void receivePacket(Player sender) {
         try {
-            ProtocolLibrary.getProtocolManager().recieveClientPacket(sender,
+            ProtocolLibrary.getProtocolManager().receiveClientPacket(sender,
                     getHandle());
         } catch (Exception e) {
             throw new RuntimeException("Cannot receive packet.", e);

--- a/BetterRTPAddons/src/main/resources/plugin.yml
+++ b/BetterRTPAddons/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: me.SuperRonanCraft.BetterRTPAddons.Main
 version: ${project.version}
-api-version: '1.13'
+api-version: '1.21'
 folia-supported: true
 name: BetterRTPAddons
 depend: [BetterRTP]

--- a/BetterRTPAddons/src/main/resources/plugin.yml
+++ b/BetterRTPAddons/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: me.SuperRonanCraft.BetterRTPAddons.Main
 version: ${project.version}
-api-version: '1.21'
+api-version: '26.1'
 folia-supported: true
 name: BetterRTPAddons
 depend: [BetterRTP]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ feel free to fork one of the language files and help translate!
 BetterRTP uses and is compiled with the following libraries:
 
 - [ParticleLib](https://github.com/ByteZ1337/ParticleLib) (included) - Particles library by ByteZ1337. Find all supported particles [here](https://github.com/ByteZ1337/ParticleLib/blob/master/src/main/java/xyz/xenondevs/particle/ParticleEffect.java)
-- [PaperLib](https://github.com/PaperMC/PaperLib) (included) - Library for interfacing with PaperMC specific APIs, used for async chunk loading.
+- [Folia API](https://github.com/PaperMC/Folia) (provided) - Modern Folia server API target for chunk loading and scheduler compatibility.
 - [FoliaLib](https://github.com/TechnicallyCoded/FoliaLib) (included) - Library for interfacing with Folia specific APIs, used for cross-platform timers.
 
 ## Build instructions on Ubuntu

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ BetterRTP uses and is compiled with the following libraries:
 - [Folia API](https://github.com/PaperMC/Folia) (provided) - Modern Folia server API target for chunk loading and scheduler compatibility.
 - [FoliaLib](https://github.com/TechnicallyCoded/FoliaLib) (included) - Library for interfacing with Folia specific APIs, used for cross-platform timers.
 
+Builds targeting Folia 26.1.2+ require Java 25 or newer.
+
 ## Build instructions on Ubuntu
 
 mvn clean install

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ BetterRTP uses and is compiled with the following libraries:
 
 Builds targeting Folia 26.1.2+ require Java 25 or newer.
 
+The main plugin and BetterRTPAddons target the Folia 26.1.2 build 8 API and declare `api-version: '26.1'`. CI also boots the shaded BetterRTP jar on that exact stable Folia build and runs plugin version and configuration smoke checks.
+
 ## Build instructions on Ubuntu
 
 mvn clean install

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <!-- Upload patches to https://repo.ronanplugins.com/#/ -->
 
     <properties>
-        <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -50,7 +50,7 @@
                 <version>3.1.4</version>
             </plugin>
             <plugin>
-                <!-- Shade PaperLib into project -->
+                <!-- Shade runtime libraries into project -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.0</version>
@@ -58,10 +58,6 @@
                     <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml
                     </dependencyReducedPomLocation>
                     <relocations>
-                        <relocation>
-                            <pattern>io.papermc.lib</pattern>
-                            <shadedPattern>me.SuperRonanCraft.BetterRTP.lib.paperlib</shadedPattern>
-                        </relocation>
                         <relocation>
                             <pattern>com.tcoded.folialib</pattern>
                             <shadedPattern>me.SuperRonanCraft.BetterRTP.lib.folialib</shadedPattern>
@@ -82,8 +78,17 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>21</source>
+                    <target>21</target>
+                    <release>21</release>
+                    <proc>full</proc>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.38</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
         </plugins>
@@ -164,18 +169,11 @@
         </repository>
     </repositories>
     <dependencies>
-        <!--Spigot API-->
+        <!-- Folia API -->
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <!-- Spigot Stuff -->
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
+            <groupId>dev.folia</groupId>
+            <artifactId>folia-api</artifactId>
+            <version>26.1.2.build.8-stable</version>
             <scope>provided</scope>
         </dependency>
         <!-- Vault -->
@@ -184,13 +182,6 @@
             <artifactId>VaultAPI</artifactId>
             <version>1.7</version>
             <scope>provided</scope>
-        </dependency>
-        <!-- Paper Library for Async Chunk/Teleport -->
-        <dependency>
-            <groupId>io.papermc</groupId>
-            <artifactId>paperlib</artifactId>
-            <version>1.0.8</version>
-            <scope>compile</scope>
         </dependency>
         <!-- WorldGuard (https://dev.bukkit.org/projects/worldguard) -->
         <dependency> <!-- Saber Factions screws up if updated -->

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
                 <!-- Shade runtime libraries into project -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.6.2</version>
                 <configuration>
                     <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml
                     </dependencyReducedPomLocation>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <!-- Upload patches to https://repo.ronanplugins.com/#/ -->
 
     <properties>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -78,9 +78,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
-                    <release>21</release>
+                    <source>25</source>
+                    <target>25</target>
+                    <release>25</release>
                     <proc>full</proc>
                     <annotationProcessorPaths>
                         <path>

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/BetterRTP.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/BetterRTP.java
@@ -21,6 +21,7 @@ import me.SuperRonanCraft.BetterRTP.references.rtpinfo.QueueHandler;
 import me.SuperRonanCraft.BetterRTP.references.settings.Settings;
 import me.SuperRonanCraft.BetterRTP.references.web.Metrics;
 import me.SuperRonanCraft.BetterRTP.references.web.Updater;
+import me.SuperRonanCraft.BetterRTP.versions.AsyncHandler;
 import me.SuperRonanCraft.BetterRTP.versions.FoliaHandler;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -66,7 +67,8 @@ public class BetterRTP extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        invs.closeAll();
+        invs.unload();
+        pInfo.unloadAll();
         queue.unload();
         rtpLogger.unload();
     }
@@ -92,9 +94,11 @@ public class BetterRTP extends JavaPlugin {
     }
 
     public void reload(CommandSender sendi) {
-        invs.closeAll();
-        loadAll();
-        MessagesCore.RELOAD.send(sendi);
+        AsyncHandler.sync(() -> {
+            invs.closeAll();
+            loadAll();
+            MessagesCore.RELOAD.send(sendi);
+        });
     }
 
     //(Re)Load all plugin systems/files/cache

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/player/PlayerInfo.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/player/PlayerInfo.java
@@ -1,6 +1,7 @@
 package me.SuperRonanCraft.BetterRTP.player;
 
-import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -11,12 +12,12 @@ import me.SuperRonanCraft.BetterRTP.references.invs.RTP_INV_SETTINGS;
 
 public class PlayerInfo {
 
-    private final HashMap<Player, Inventory> invs = new HashMap<>();
+    private final Map<Player, Inventory> invs = new ConcurrentHashMap<>();
     //private final HashMap<Player, RTP_INV_SETTINGS> invType = new HashMap<>();
-    @Getter private final HashMap<Player, World> invWorld = new HashMap<>();
-    @Getter private final HashMap<Player, RTP_INV_SETTINGS> invNextInv = new HashMap<>();
+    @Getter private final Map<Player, World> invWorld = new ConcurrentHashMap<>();
+    @Getter private final Map<Player, RTP_INV_SETTINGS> invNextInv = new ConcurrentHashMap<>();
     //private final HashMap<Player, CooldownData> cooldown = new HashMap<>();
-    @Getter private final HashMap<Player, Boolean> rtping = new HashMap<>();
+    @Getter private final Map<Player, Boolean> rtping = new ConcurrentHashMap<>();
     //private final HashMap<Player, List<Location>> previousLocations = new HashMap<>();
     //private final HashMap<Player, RTP_TYPE> rtpType = new HashMap<>();
 
@@ -42,7 +43,7 @@ public class PlayerInfo {
         return invs.containsKey(p);
     }
 
-    private void unloadAll() {
+    public void unloadAll() {
         invs.clear();
         //invType.clear();
         invWorld.clear();
@@ -52,7 +53,7 @@ public class PlayerInfo {
         //previousLocations.clear();
     }
 
-    private void unload(Player p) {
+    public void unload(Player p) {
         clearInvs(p);
         //cooldown.remove(p);
         rtping.remove(p);

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/player/commands/types/CmdPlayer.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/player/commands/types/CmdPlayer.java
@@ -19,6 +19,7 @@ import me.SuperRonanCraft.BetterRTP.references.helpers.HelperRTP;
 import me.SuperRonanCraft.BetterRTP.references.messages.MessagesCore;
 import me.SuperRonanCraft.BetterRTP.references.messages.MessagesHelp;
 import me.SuperRonanCraft.BetterRTP.references.messages.MessagesUsage;
+import me.SuperRonanCraft.BetterRTP.versions.AsyncHandler;
 
 public class CmdPlayer implements RTPCommand, RTPCommandHelpable {
 
@@ -28,38 +29,37 @@ public class CmdPlayer implements RTPCommand, RTPCommandHelpable {
 
     //rtp player <player> <world> <RTP_PlayerInfo.RTP_PLAYERINFO_FLAG...>
     public void execute(CommandSender sendi, String label, String[] args) {
-        if (args.length == 2)
-            if (Bukkit.getPlayer(args[1]) != null && Bukkit.getPlayer(args[1]).isOnline()) {
-                HelperRTP.tp(Bukkit.getPlayer(args[1]),
-                        sendi,
-                        Bukkit.getPlayer(args[1]).getWorld(),
-                        null,
-                        RTP_TYPE.FORCED,
-                        null,
-                        new RTP_PlayerInfo());
-            } else if (Bukkit.getPlayer(args[1]) != null)
-                MessagesCore.NOTONLINE.send(sendi, args[1]);
-            else
-                usage(sendi, label);
-        else if (args.length >= 3)
-            if (Bukkit.getPlayer(args[1]) != null && Bukkit.getPlayer(args[1]).isOnline()) {
-                World world = Bukkit.getWorld(args[2]);
-                if (world != null) {
-                    HelperRTP.tp(Bukkit.getPlayer(args[1]),
-                            sendi,
-                            world,
-                            null,
-                            RTP_TYPE.FORCED,
-                            null,
-                            getFlags(args));
-                } else
-                    MessagesCore.NOTEXIST.send(sendi, args[2]);
-            } else if (Bukkit.getPlayer(args[1]) != null)
-                MessagesCore.NOTONLINE.send(sendi, args[1]);
-            else
-                usage(sendi, label);
-        else
+        if (args.length < 2) {
             usage(sendi, label);
+            return;
+        }
+
+        Player player = Bukkit.getPlayer(args[1]);
+        if (player == null) {
+            usage(sendi, label);
+            return;
+        }
+
+        World requestedWorld = args.length >= 3 ? Bukkit.getWorld(args[2]) : null;
+        if (args.length >= 3 && requestedWorld == null) {
+            MessagesCore.NOTEXIST.send(sendi, args[2]);
+            return;
+        }
+
+        RTP_PlayerInfo playerInfo = args.length >= 3 ? getFlags(args) : new RTP_PlayerInfo();
+        AsyncHandler.syncAtEntity(player, () -> {
+            if (!player.isOnline()) {
+                MessagesCore.NOTONLINE.send(sendi, player.getName());
+                return;
+            }
+            HelperRTP.tp(player,
+                    sendi,
+                    requestedWorld != null ? requestedWorld : player.getWorld(),
+                    null,
+                    RTP_TYPE.FORCED,
+                    null,
+                    playerInfo);
+        }, () -> MessagesCore.NOTONLINE.send(sendi, args[1]));
     }
 
     private RTP_PlayerInfo getFlags(String[] args) {

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/player/commands/types/CmdPlayerSudo.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/player/commands/types/CmdPlayerSudo.java
@@ -17,6 +17,7 @@ import me.SuperRonanCraft.BetterRTP.references.PermissionNode;
 import me.SuperRonanCraft.BetterRTP.references.helpers.HelperRTP;
 import me.SuperRonanCraft.BetterRTP.references.messages.MessagesCore;
 import me.SuperRonanCraft.BetterRTP.references.messages.MessagesUsage;
+import me.SuperRonanCraft.BetterRTP.versions.AsyncHandler;
 
 public class CmdPlayerSudo implements RTPCommand {
 
@@ -26,38 +27,36 @@ public class CmdPlayerSudo implements RTPCommand {
 
     //rtp sudoplayer <player> <world> <RTP_PlayerInfo.RTP_PLAYERINFO_FLAG...>
     public void execute(CommandSender sendi, String label, String[] args) {
-        if (args.length == 2)
-            if (Bukkit.getPlayer(args[1]) != null && Bukkit.getPlayer(args[1]).isOnline()) {
-                HelperRTP.tp(Bukkit.getPlayer(args[1]),
-                        sendi,
-                        Bukkit.getPlayer(args[1]).getWorld(),
-                        null,
-                        RTP_TYPE.FORCED,
-                        null,
-                        new RTP_PlayerInfo(false, true, false, false, false));
-            } else if (Bukkit.getPlayer(args[1]) != null)
-                MessagesCore.NOTONLINE.send(sendi, args[1]);
-            else
-                usage(sendi, label);
-        else if (args.length >= 3)
-            if (Bukkit.getPlayer(args[1]) != null && Bukkit.getPlayer(args[1]).isOnline()) {
-                World world = Bukkit.getWorld(args[2]);
-                if (world != null) {
-                    HelperRTP.tp(Bukkit.getPlayer(args[1]),
-                            sendi,
-                            world,
-                            null,
-                            RTP_TYPE.FORCED,
-                            null,
-                            new RTP_PlayerInfo(false, true, false, false, false));
-                } else
-                    MessagesCore.NOTEXIST.send(sendi, args[2]);
-            } else if (Bukkit.getPlayer(args[1]) != null)
-                MessagesCore.NOTONLINE.send(sendi, args[1]);
-            else
-                usage(sendi, label);
-        else
+        if (args.length < 2) {
             usage(sendi, label);
+            return;
+        }
+
+        Player player = Bukkit.getPlayer(args[1]);
+        if (player == null) {
+            usage(sendi, label);
+            return;
+        }
+
+        World requestedWorld = args.length >= 3 ? Bukkit.getWorld(args[2]) : null;
+        if (args.length >= 3 && requestedWorld == null) {
+            MessagesCore.NOTEXIST.send(sendi, args[2]);
+            return;
+        }
+
+        AsyncHandler.syncAtEntity(player, () -> {
+            if (!player.isOnline()) {
+                MessagesCore.NOTONLINE.send(sendi, player.getName());
+                return;
+            }
+            HelperRTP.tp(player,
+                    sendi,
+                    requestedWorld != null ? requestedWorld : player.getWorld(),
+                    null,
+                    RTP_TYPE.FORCED,
+                    null,
+                    new RTP_PlayerInfo(false, true, false, false, false));
+        }, () -> MessagesCore.NOTONLINE.send(sendi, args[1]));
     }
 
     public List<String> tabComplete(CommandSender sendi, String[] args) {

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/player/events/Leave.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/player/events/Leave.java
@@ -1,5 +1,6 @@
 package me.SuperRonanCraft.BetterRTP.player.events;
 
+import me.SuperRonanCraft.BetterRTP.BetterRTP;
 import me.SuperRonanCraft.BetterRTP.references.player.HelperPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -8,6 +9,7 @@ class Leave {
 
     static void event(PlayerQuitEvent e) {
         Player p = e.getPlayer();
+        BetterRTP.getInstance().getPInfo().unload(p);
         HelperPlayer.unload(p);
     }
 }

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/player/rtp/RTPDelay.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/player/rtp/RTPDelay.java
@@ -27,7 +27,7 @@ class RTPDelay implements Listener {
 
     private void delay(CommandSender sendi, int delay) {
         if (!getPl().getRTP().getTeleport().beforeTeleportDelay(rtp.getPlayer(), delay)) {
-            task = AsyncHandler.syncLater(run(sendi, this), delay * 20L);
+            task = AsyncHandler.syncAtEntityLater(rtp.getPlayer(), run(sendi, this), delay * 20L);
             if (cancelOnMove || cancelOnDamage)
                 Bukkit.getPluginManager().registerEvents(this, BetterRTP.getInstance());
         }

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/player/rtp/RTPPlayer.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/player/rtp/RTPPlayer.java
@@ -8,7 +8,6 @@ import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import io.papermc.lib.PaperLib;
 import lombok.Getter;
 import me.SuperRonanCraft.BetterRTP.BetterRTP;
 import me.SuperRonanCraft.BetterRTP.references.customEvents.RTP_FailedEvent;
@@ -38,7 +37,7 @@ public class RTPPlayer {
 
     void randomlyTeleport(CommandSender sendi) {
         if (attempts >= settings.maxAttempts) //Cancel out, too many tries
-            metMax(sendi, player);
+            AsyncHandler.syncAtEntity(player, () -> metMax(sendi, player));
         else { //Try again to find a safe location
             //Find a location from another Plugin
             RTP_FindLocationEvent event = new RTP_FindLocationEvent(this); //Find an external plugin location
@@ -62,20 +61,20 @@ public class RTPPlayer {
                         loc = RandomLocation.generateLocation(worldPlayer);
                 }
                 attempts++; //Add an attempt
+                if (loc == null) {
+                    AsyncHandler.syncAtEntity(player, () -> randomlyTeleport(sendi));
+                    return;
+                }
                 //Load chunk and find out if safe location (asynchronously)
-                AsyncHandler.sync(() -> {
-                    try { //Prior to 1.12 this async chunk will NOT work
-                        CompletableFuture<Chunk> chunk = PaperLib.getChunkAtAsync(loc);
-                        chunk.thenAccept(result -> {
-                            //BetterRTP.debug("Checking location for " + p.getName());
-                            attempt(sendi, loc);
-                        });
-                    } catch (IllegalStateException e) {
-                        //Legacy non-async support
-                        attempt(sendi, loc);
-                    } catch (Throwable ignored) {
-
-                    }
+                AsyncHandler.syncAtLocation(loc, () -> {
+                    CompletableFuture<Chunk> chunk = loc.getWorld().getChunkAtAsync(loc);
+                    chunk.thenAccept(result -> {
+                        //BetterRTP.debug("Checking location for " + p.getName());
+                        AsyncHandler.syncAtLocation(loc, () -> attempt(sendi, loc));
+                    }).exceptionally(ex -> {
+                        AsyncHandler.syncAtEntity(player, () -> randomlyTeleport(sendi));
+                        return null;
+                    });
                 });
             });
         }
@@ -87,22 +86,26 @@ public class RTPPlayer {
         //attemptedLocations.add(loc);
         //Valid location?
         if (tpLoc != null && checkDepends(tpLoc)) {
-            tpLoc.add(0.5, 0, 0.5); //Center location
-            if (getPl().getEco().charge(player, worldPlayer)) {
-                //Successfully found a safe location, set cooldown and teleport player.
-                if (worldPlayer.getPlayerInfo().isApplyCooldown() && HelperRTP_Check.applyCooldown(player))
-                    getPl().getCooldowns().add(player, worldPlayer.getWorld());
-                tpLoc.setYaw(player.getLocation().getYaw());
-                tpLoc.setPitch(player.getLocation().getPitch());
-                AsyncHandler.sync(() -> settings.teleport.sendPlayer(sendi, player, tpLoc, worldPlayer, attempts, type));
-            } else {
-                if (worldPlayer.getPlayerInfo().applyCooldown)
-                    getPl().getCooldowns().removeCooldown(player, worldPlayer.getWorld());
-                getPl().getPInfo().getRtping().remove(player);
-            }
+            AsyncHandler.syncAtEntity(player, () -> teleport(sendi, tpLoc));
         } else {
-            randomlyTeleport(sendi);
             QueueHandler.remove(loc);
+            AsyncHandler.syncAtEntity(player, () -> randomlyTeleport(sendi));
+        }
+    }
+
+    private void teleport(CommandSender sendi, Location tpLoc) {
+        tpLoc.add(0.5, 0, 0.5); //Center location
+        if (getPl().getEco().charge(player, worldPlayer)) {
+            //Successfully found a safe location, set cooldown and teleport player.
+            if (worldPlayer.getPlayerInfo().isApplyCooldown() && HelperRTP_Check.applyCooldown(player))
+                getPl().getCooldowns().add(player, worldPlayer.getWorld());
+            tpLoc.setYaw(player.getLocation().getYaw());
+            tpLoc.setPitch(player.getLocation().getPitch());
+            settings.teleport.sendPlayer(sendi, player, tpLoc, worldPlayer, attempts, type);
+        } else {
+            if (worldPlayer.getPlayerInfo().applyCooldown)
+                getPl().getCooldowns().removeCooldown(player, worldPlayer.getWorld());
+            getPl().getPInfo().getRtping().remove(player);
         }
     }
 

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/player/rtp/RTPTeleport.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/player/rtp/RTPTeleport.java
@@ -5,9 +5,7 @@ import java.util.Arrays;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 
-import io.papermc.lib.PaperLib;
 import me.SuperRonanCraft.BetterRTP.BetterRTP;
 import me.SuperRonanCraft.BetterRTP.player.rtp.effects.RTPEffect_Titles;
 import me.SuperRonanCraft.BetterRTP.player.rtp.effects.RTPEffects;
@@ -17,12 +15,7 @@ import me.SuperRonanCraft.BetterRTP.references.customEvents.RTP_TeleportPostEven
 import me.SuperRonanCraft.BetterRTP.references.customEvents.RTP_TeleportPreEvent;
 import me.SuperRonanCraft.BetterRTP.references.messages.MessagesCore;
 import me.SuperRonanCraft.BetterRTP.references.rtpinfo.worlds.WorldPlayer;
-
-//---
-//Credit to @PaperMC for PaperLib - https://github.com/PaperMC/PaperLib
-//
-//Use of asyncronous chunk loading and teleporting
-//---
+import me.SuperRonanCraft.BetterRTP.versions.AsyncHandler;
 
 public class RTPTeleport {
 
@@ -42,19 +35,16 @@ public class RTPTeleport {
                     final int attempts, RTP_TYPE type) throws NullPointerException {
         Location oldLoc = p.getLocation();
         loadingTeleport(p, sendi); //Send loading message to player who requested
-        //List<CompletableFuture<Chunk>> asyncChunks = getChunks(location); //Get a list of chunks
-        //playerLoads.put(p, asyncChunks);
-        /*CompletableFuture.allOf(asyncChunks.toArray(new CompletableFuture[] {})).thenRun(() -> { //Async chunk load
-            new BukkitRunnable() { //Run synchronously
-                @Override
-                public void run() {*/
         try {
             RTP_TeleportEvent event = new RTP_TeleportEvent(p, location, wPlayer.getWorldtype());
             getPl().getServer().getPluginManager().callEvent(event);
             Location loc = event.getLocation();
-            PaperLib.teleportAsync(p, loc).thenRun(new BukkitRunnable() { //Async teleport
-                @Override
-                public void run() {
+            AsyncHandler.teleportAsync(p, loc).thenAccept(success -> {
+                if (!success) {
+                    AsyncHandler.syncAtEntity(p, () -> getPl().getPInfo().getRtping().remove(p));
+                    return;
+                }
+                AsyncHandler.syncAtEntity(p, () -> {
                     afterTeleport(p, loc, wPlayer, attempts, oldLoc, type);
                     if (sendi != p) //Tell player who requested that the player rtp'd
                         sendSuccessMsg(sendi, p.getName(), loc, wPlayer, false, attempts);
@@ -63,7 +53,11 @@ public class RTPTeleport {
                     if (type == RTP_TYPE.JOIN) //RTP Type was Join
                         if (BetterRTP.getInstance().getSettings().isRtpOnFirstJoin_SetAsRespawn()) //Save as respawn is enabled
                             p.setBedSpawnLocation(loc, true); //True means to force a respawn even without a valid bed
-                }
+                });
+            }).exceptionally(ex -> {
+                AsyncHandler.syncAtEntity(p, () -> getPl().getPInfo().getRtping().remove(p));
+                ex.printStackTrace();
+                return null;
             });
         } catch (Exception e) {
             getPl().getPInfo().getRtping().remove(p); //No longer rtp'ing (errored)
@@ -135,18 +129,6 @@ public class RTPTeleport {
     }
 
     //Processing
-
-    /*private List<CompletableFuture<Chunk>> getChunks(Location loc) { //List all chunks in range to load
-        List<CompletableFuture<Chunk>> asyncChunks = new ArrayList<>();
-        int range = Math.round(Math.max(0, Math.min(16, getPl().getSettings().getPreloadRadius())));
-        for (int x = -range; x <= range; x++)
-            for (int z = -range; z <= range; z++) {
-                Location locLoad = new Location(loc.getWorld(), loc.getX() + (x * 16), loc.getY(), loc.getZ() + (z * 16));
-                CompletableFuture<Chunk> chunk = PaperLib.getChunkAtAsync(locLoad, true);
-                asyncChunks.add(chunk);
-            }
-        return asyncChunks;
-    }*/
 
     private void sendSuccessMsg(CommandSender sendi, String player, Location loc, WorldPlayer wPlayer, boolean sameAsPlayer, int attempts) {
         if (sameAsPlayer) {

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/player/rtp/effects/RTPEffect_Particles.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/player/rtp/effects/RTPEffect_Particles.java
@@ -70,7 +70,7 @@ public class RTPEffect_Particles {
 
     public void display(Player p) {
         if (!enabled) return;
-        AsyncHandler.async(() -> {
+        AsyncHandler.syncAtEntity(p, () -> {
             try { //Incase the library errors out
                 switch (shape) {
                     case "TELEPORT":

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/references/invs/RTPInventories.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/references/invs/RTPInventories.java
@@ -2,6 +2,7 @@ package me.SuperRonanCraft.BetterRTP.references.invs;
 
 import me.SuperRonanCraft.BetterRTP.references.invs.enums.RTPInventory_Defaults;
 import me.SuperRonanCraft.BetterRTP.BetterRTP;
+import me.SuperRonanCraft.BetterRTP.versions.AsyncHandler;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -22,10 +23,15 @@ public class RTPInventories {
     public void closeAll() {
         BetterRTP main = BetterRTP.getInstance();
         for (Player p : Bukkit.getOnlinePlayers())
-            if (main.getPInfo().playerExists(p)) {
-                main.getPInfo().clearInvs(p);
-                p.closeInventory();
-            }
+            if (main.getPInfo().playerExists(p))
+                AsyncHandler.syncAtEntity(p, () -> {
+                    main.getPInfo().clearInvs(p);
+                    p.closeInventory();
+                });
+    }
+
+    public void unload() {
+        invs.clear();
     }
 
     public RTPInventory_Defaults getInv(RTP_INV_SETTINGS type) {

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/references/messages/Message.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/references/messages/Message.java
@@ -22,25 +22,25 @@ public interface Message {
 
     static void sms(Message messenger, CommandSender sendi, String msg) {
         if (!msg.isEmpty())
-            AsyncHandler.sync(() ->
+            AsyncHandler.syncAtSender(sendi, () ->
                     sendi.sendMessage(placeholder(sendi, getPrefix(messenger) + msg)));
     }
 
     static void sms(Message messenger, CommandSender sendi, String msg, Object placeholderInfo) {
         if (!msg.isEmpty())
-            AsyncHandler.sync(() ->
+            AsyncHandler.syncAtSender(sendi, () ->
                     sendi.sendMessage(Objects.requireNonNull(placeholder(sendi, getPrefix(messenger) + msg, placeholderInfo))));
     }
 
     static void sms(Message messenger, CommandSender sendi, String msg, List<Object> placeholderInfo) {
         if (!msg.isEmpty())
-            AsyncHandler.sync(() ->
+            AsyncHandler.syncAtSender(sendi, () ->
                     sendi.sendMessage(placeholder(sendi, getPrefix(messenger) + msg, placeholderInfo)));
     }
 
     static void sms(CommandSender sendi, List<String> msg, Object placeholderInfo) {
         if (msg != null && !msg.isEmpty()) {
-            AsyncHandler.sync(() -> {
+            AsyncHandler.syncAtSender(sendi, () -> {
                 msg.forEach(str -> msg.set(msg.indexOf(str), placeholder(sendi, str, placeholderInfo)));
                 sendi.sendMessage(msg.toArray(new String[0]));
             });

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/references/rtpinfo/QueueGenerator.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/references/rtpinfo/QueueGenerator.java
@@ -3,15 +3,16 @@ package me.SuperRonanCraft.BetterRTP.references.rtpinfo;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.jetbrains.annotations.Nullable;
 
 import com.tcoded.folialib.wrapper.task.WrappedTask;
 
-import io.papermc.lib.PaperLib;
 import me.SuperRonanCraft.BetterRTP.BetterRTP;
 import me.SuperRonanCraft.BetterRTP.player.commands.RTP_SETUP_TYPE;
 import me.SuperRonanCraft.BetterRTP.player.rtp.RTP;
@@ -156,41 +157,49 @@ public class QueueGenerator {
     private void addQueue(RTPWorld rtpWorld, String id, ReQueueData reQueueData) {
         Location loc = RandomLocation.generateLocation(rtpWorld);
         if (loc != null) {
-            AsyncHandler.sync(() -> {
+            AsyncHandler.syncAtLocation(loc, () -> {
                 //BetterRTP.debug("Queued up a new position, attempts " + reQueueData.attempts);
-                PaperLib.getChunkAtAsync(loc)
-                        .thenAccept(v -> {
-                            Location safeLoc = RandomLocation.getSafeLocation(
-                                    HelperRTP.getWorldType(rtpWorld.getWorld()),
-                                    loc.getWorld(),
-                                    loc,
-                                    rtpWorld.getMinY(),
-                                    rtpWorld.getMaxY(),
-                                    rtpWorld.getBiomes());
-                            //data.setLocation(safeLoc);
-                            if (safeLoc != null) {
-                                AsyncHandler.async(() -> {
-                                    QueueData data = DatabaseHandler.getQueue().addQueue(safeLoc);
-                                    if (data != null) {
-                                        //queueList.add(data);
-                                        String _x = String.valueOf(data.getLocation().getBlockX());
-                                        String _y = String.valueOf(data.getLocation().getBlockY());
-                                        String _z = String.valueOf(data.getLocation().getBlockZ());
-                                        String _world = data.getLocation().getWorld().getName();
-                                        BetterRTP.debug("Queue position generated"
-                                                + ": id= " + id + ", database_ID= " + data.database_id
-                                                + ", location= x: " + _x + ", y: " + _y + ", z: " + _z + ", world: " + _world);
-                                    } else
-                                        BetterRTP.debug("Database error occurred for a queue when trying to save: " + safeLoc);
-                                    queueGenerator(reQueueData);
-                                });
-                            } else
-                                queueGenerator(reQueueData);
+                CompletableFuture<Chunk> chunk = loc.getWorld().getChunkAtAsync(loc);
+                chunk.thenAccept(v -> AsyncHandler.syncAtLocation(loc, () -> checkQueueLocation(rtpWorld, id, reQueueData, loc)))
+                        .exceptionally(ex -> {
+                            queueGenerator(reQueueData);
+                            return null;
                         });
             });
         } else {
             BetterRTP.debug("Queue position wasn't able to generate a location!");
             queueGenerator(reQueueData);
         }
+    }
+
+    private void checkQueueLocation(RTPWorld rtpWorld, String id, ReQueueData reQueueData, Location loc) {
+        Location safeLoc = RandomLocation.getSafeLocation(
+                HelperRTP.getWorldType(rtpWorld.getWorld()),
+                loc.getWorld(),
+                loc,
+                rtpWorld.getMinY(),
+                rtpWorld.getMaxY(),
+                rtpWorld.getBiomes());
+        //data.setLocation(safeLoc);
+        if (safeLoc != null) {
+            AsyncHandler.async(() -> saveQueueLocation(id, reQueueData, safeLoc));
+        } else
+            queueGenerator(reQueueData);
+    }
+
+    private void saveQueueLocation(String id, ReQueueData reQueueData, Location safeLoc) {
+        QueueData data = DatabaseHandler.getQueue().addQueue(safeLoc);
+        if (data != null) {
+            //queueList.add(data);
+            String _x = String.valueOf(data.getLocation().getBlockX());
+            String _y = String.valueOf(data.getLocation().getBlockY());
+            String _z = String.valueOf(data.getLocation().getBlockZ());
+            String _world = data.getLocation().getWorld().getName();
+            BetterRTP.debug("Queue position generated"
+                    + ": id= " + id + ", database_ID= " + data.database_id
+                    + ", location= x: " + _x + ", y: " + _y + ", z: " + _z + ", world: " + _world);
+        } else
+            BetterRTP.debug("Database error occurred for a queue when trying to save: " + safeLoc);
+        queueGenerator(reQueueData);
     }
 }

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/references/rtpinfo/RandomLocation.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/references/rtpinfo/RandomLocation.java
@@ -1,9 +1,9 @@
 package me.SuperRonanCraft.BetterRTP.references.rtpinfo;
 
-import io.papermc.lib.PaperLib;
 import me.SuperRonanCraft.BetterRTP.BetterRTP;
 import me.SuperRonanCraft.BetterRTP.references.rtpinfo.worlds.RTPWorld;
 import me.SuperRonanCraft.BetterRTP.references.rtpinfo.worlds.WORLD_TYPE;
+import me.SuperRonanCraft.BetterRTP.versions.AsyncHandler;
 import org.bukkit.*;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
@@ -155,20 +155,27 @@ public class RandomLocation {
     }
 
     private static void cacheChunkAt(World world, int goal, int start, int xat, int zat) {
-        CompletableFuture<Chunk> task = PaperLib.getChunkAtAsync(new Location(world, xat * 16, 0, zat * 16));
-        task.thenAccept(chunk -> {
-            try {
-                ChunkSnapshot snapshot = chunk.getChunkSnapshot(true, true, false);
-                int maxy = snapshot.getHighestBlockYAt(8, 8);
-                Biome biome = snapshot.getBiome(8, 8);
-                //BetterRTP.getInstance().getLogger().info("Added " + chunk.getX() + " " + chunk.getZ());
-                BetterRTP.getInstance().getDatabaseHandler().getDatabaseChunks().addChunk(chunk, maxy, biome);
-            } catch (Throwable e) {
-                e.printStackTrace();
-                throw new RuntimeException();
-                //BetterRTP.getInstance().getLogger().info("Tried Adding " + chunk.getX() + " " + chunk.getZ());
-            }
-        }).thenRun(() -> cacheTask(world, goal, start, xat, zat));
+        Location loc = new Location(world, xat * 16, 0, zat * 16);
+        AsyncHandler.syncAtLocation(loc, () -> {
+            CompletableFuture<Chunk> task = loc.getWorld().getChunkAtAsync(loc);
+            task.thenAccept(chunk -> AsyncHandler.syncAtLocation(loc, () -> {
+                try {
+                    ChunkSnapshot snapshot = chunk.getChunkSnapshot(true, true, false);
+                    int maxy = snapshot.getHighestBlockYAt(8, 8);
+                    Biome biome = snapshot.getBiome(8, 8);
+                    //BetterRTP.getInstance().getLogger().info("Added " + chunk.getX() + " " + chunk.getZ());
+                    BetterRTP.getInstance().getDatabaseHandler().getDatabaseChunks().addChunk(chunk, maxy, biome);
+                } catch (Throwable e) {
+                    e.printStackTrace();
+                    //BetterRTP.getInstance().getLogger().info("Tried Adding " + chunk.getX() + " " + chunk.getZ());
+                }
+                cacheTask(world, goal, start, xat, zat);
+            })).exceptionally(ex -> {
+                ex.printStackTrace();
+                AsyncHandler.syncAtLocation(loc, () -> cacheTask(world, goal, start, xat, zat));
+                return null;
+            });
+        });
     }
 
 }

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/versions/AsyncHandler.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/versions/AsyncHandler.java
@@ -3,7 +3,10 @@ package me.SuperRonanCraft.BetterRTP.versions;
 import com.tcoded.folialib.impl.ServerImplementation;
 import com.tcoded.folialib.wrapper.task.WrappedTask;
 import me.SuperRonanCraft.BetterRTP.BetterRTP;
+import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+
+import java.util.concurrent.CompletableFuture;
 
 public class AsyncHandler {
 
@@ -19,11 +22,33 @@ public class AsyncHandler {
         getFolia().runAtEntity(entity, task -> runnable.run());
     }
 
+    public static void syncAtLocation(Location location, Runnable runnable) {
+        getFolia().runAtLocation(location, task -> runnable.run());
+    }
+
+    public static CompletableFuture<Boolean> teleportAsync(Entity entity, Location location) {
+        return getFolia().teleportAsync(entity, location);
+    }
+
     public static WrappedTask asyncLater(Runnable runnable, long ticks) {
         return getFolia().runLaterAsync(runnable, ticks);
     }
+
     public static WrappedTask syncLater(Runnable runnable, long ticks) {
         return getFolia().runLater(runnable, ticks);
+    }
+
+    public static WrappedTask syncAtEntityLater(Entity entity, Runnable runnable, long ticks) {
+        return getFolia().runAtEntityLater(entity, runnable, ticks);
+    }
+
+    public static Object syncAtEntityLaterTask(Entity entity, Runnable runnable, long ticks) {
+        return syncAtEntityLater(entity, runnable, ticks);
+    }
+
+    public static void cancelTask(Object task) {
+        if (task instanceof WrappedTask)
+            ((WrappedTask) task).cancel();
     }
 
     private static ServerImplementation getFolia() {

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/versions/AsyncHandler.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/versions/AsyncHandler.java
@@ -4,6 +4,7 @@ import com.tcoded.folialib.impl.ServerImplementation;
 import com.tcoded.folialib.wrapper.task.WrappedTask;
 import me.SuperRonanCraft.BetterRTP.BetterRTP;
 import org.bukkit.Location;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 
 import java.util.concurrent.CompletableFuture;
@@ -19,7 +20,18 @@ public class AsyncHandler {
     }
 
     public static void syncAtEntity(Entity entity, Runnable runnable) {
-        getFolia().runAtEntity(entity, task -> runnable.run());
+        syncAtEntity(entity, runnable, () -> { });
+    }
+
+    public static void syncAtEntity(Entity entity, Runnable runnable, Runnable retired) {
+        getFolia().runAtEntityWithFallback(entity, task -> runnable.run(), retired);
+    }
+
+    public static void syncAtSender(CommandSender sender, Runnable runnable) {
+        if (sender instanceof Entity entity)
+            syncAtEntity(entity, runnable);
+        else
+            sync(runnable);
     }
 
     public static void syncAtLocation(Location location, Runnable runnable) {

--- a/src/main/java/me/SuperRonanCraft/BetterRTP/versions/FoliaHandler.java
+++ b/src/main/java/me/SuperRonanCraft/BetterRTP/versions/FoliaHandler.java
@@ -6,10 +6,11 @@ import me.SuperRonanCraft.BetterRTP.BetterRTP;
 
 public class FoliaHandler {
 
-    private ServerImplementation SERVER_IMPLEMENTATION;
+    private volatile ServerImplementation SERVER_IMPLEMENTATION;
 
-    public void load() {
-        this.SERVER_IMPLEMENTATION = new FoliaLib(BetterRTP.getInstance()).getImpl();
+    public synchronized void load() {
+        if (SERVER_IMPLEMENTATION == null)
+            SERVER_IMPLEMENTATION = new FoliaLib(BetterRTP.getInstance()).getImpl();
     }
 
     public ServerImplementation get() {

--- a/src/main/resources/THIRD-PARTY-NOTICES.md
+++ b/src/main/resources/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,53 @@
+# Third-Party Notices
+
+BetterRTP bundles the following third-party libraries in its plugin jar.
+
+## FoliaLib
+
+Project: https://github.com/TechnicallyCoded/FoliaLib
+License: MIT License
+
+Copyright 2023 TechnicallyCoded
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## ParticleLib
+
+Project: https://github.com/ByteZ1337/ParticleLib
+License: MIT License
+
+Copyright (c) 2021 ByteZ1337
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,7 +26,7 @@ softdepend:
     - Essentials #adds `/back` support
     - PlaceholderAPI
     - HuskClaims #Respect HuskClaims areas (https://www.spigotmc.org/resources/huskclaims-1-17-1-21-modern-golden-shovel-land-claiming-fully-cross-server-compatible.114467/) (fixes race condition that breaks hooking)
-api-version: '1.13'
+api-version: '1.21'
 
 commands:
     betterrtp:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,7 +26,7 @@ softdepend:
     - Essentials #adds `/back` support
     - PlaceholderAPI
     - HuskClaims #Respect HuskClaims areas (https://www.spigotmc.org/resources/huskclaims-1-17-1-21-modern-golden-shovel-land-claiming-fully-cross-server-compatible.114467/) (fixes race condition that breaks hooking)
-api-version: '1.21'
+api-version: '26.1'
 
 commands:
     betterrtp:


### PR DESCRIPTION
## Summary

- target the exact `dev.folia:folia-api:26.1.2.build.8-stable` API with Java 25 and declare `api-version: '26.1'` for BetterRTP and BetterRTPAddons
- replace legacy PaperLib chunk/teleport flows with Folia-aware region, entity, async, and teleport scheduling through FoliaLib
- keep forced-player commands, player messages, inventory cleanup, particles, delayed tasks, reloads, and shared player state on the correct scheduler or in thread-safe storage
- build both jars in CI and boot the shaded BetterRTP jar on the exact Folia 26.1.2 build 8 server, with PaperMC/Mojang artifacts pinned by SHA-256

This is intentionally a modern Folia-targeted build. Folia 26.1.2 requires Java 25.

## Verification

- `mvn -B -DskipTests clean install`
- `mvn -B -DskipTests clean package` in `BetterRTPAddons`
- [fork GitHub Actions run](https://github.com/Minecraft0122/SimpRTP/actions/runs/30100451652) passed the full build, exact Folia runtime smoke test, Addons build, and artifact upload workflow
- clean startup, plugin enable, `/brtp version`, `/brtp info`, queue generation, and shutdown on Folia `26.1.2-8`
- real player-protocol smoke test: delayed overworld RTP, live config reload, then an immediate cross-dimension RTP to the Nether; both teleports were confirmed by the client
- two-region concurrency smoke test with `threaded-regions.threads=2`: two players in regions about 5,000 blocks apart completed concurrent RTPs while background queue generation was active

No BetterRTP exceptions or Folia thread-ownership violations were observed in these runs.
